### PR TITLE
Fix bot startup and basic trade management

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 # main.py
 import asyncio
-from crypto_bot import main as run_bot   # importa a função main() definida no arquivo novo
+from crypto_bot_mexc import main as run_bot
 
 if __name__ == "__main__":
     asyncio.run(run_bot())


### PR DESCRIPTION
## Summary
- fix main entrypoint import
- allow API_KEY or MEXC_API_KEY environment variables
- implement simple trade management logic

## Testing
- `python -m py_compile crypto_bot_mexc.py main.py`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684076c19ec8832ab076deca9ae0f5c2